### PR TITLE
fix: change methods of ConversationalAgent to reference receiver

### DIFF
--- a/agents/conversational.go
+++ b/agents/conversational.go
@@ -59,7 +59,7 @@ func NewConversationalAgent(llm llms.Model, tools []tools.Tool, opts ...Option) 
 }
 
 // Plan decides what action to take or returns the final result of the input.
-func (a *ConversationalAgent) Plan(
+func (a ConversationalAgent) Plan(
 	ctx context.Context,
 	intermediateSteps []schema.AgentStep,
 	inputs map[string]string,
@@ -94,7 +94,7 @@ func (a *ConversationalAgent) Plan(
 	return a.parseOutput(output)
 }
 
-func (a *ConversationalAgent) GetInputKeys() []string {
+func (a ConversationalAgent) GetInputKeys() []string {
 	chainInputs := a.Chain.GetInputKeys()
 
 	// Remove inputs given in plan.
@@ -109,11 +109,11 @@ func (a *ConversationalAgent) GetInputKeys() []string {
 	return agentInput
 }
 
-func (a *ConversationalAgent) GetOutputKeys() []string {
+func (a ConversationalAgent) GetOutputKeys() []string {
 	return []string{a.OutputKey}
 }
 
-func (a *ConversationalAgent) GetTools() []tools.Tool {
+func (a ConversationalAgent) GetTools() []tools.Tool {
 	return a.Tools
 }
 


### PR DESCRIPTION
### PR Checklist

- [ ] Read the [Contributing documentation](https://github.com/tmc/langchaingo/blob/main/CONTRIBUTING.md).
- [ ] Read the [Code of conduct documentation](https://github.com/tmc/langchaingo/blob/main/CODE_OF_CONDUCT.md).
- [ ] Name your Pull Request title clearly, concisely, and prefixed with the name of the primarily affected package you changed according to [Good commit messages](https://go.dev/doc/contribute#commit_messages) (such as `memory: add interfaces for X, Y` or `util: add whizzbang helpers`).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `Fixes #123`).
- [ ] Describes the source of new concepts.
- [ ] References existing implementations as appropriate.
- [ ] Contains test coverage for new functions.
- [ ] Passes all [`golangci-lint`](https://golangci-lint.run/) checks.
